### PR TITLE
Enviar al paciente a la vista programarCita al guardar

### DIFF
--- a/app/controllers/sesions_controller.rb
+++ b/app/controllers/sesions_controller.rb
@@ -43,7 +43,7 @@ class SesionsController < ApplicationController
 
 
       if @sesion.save
-        format.html { render 'pacientes_pages/mis_sesiones', notice: 'sesion was successfully created.' }
+        format.html { render 'pacientes_pages/programarCita', notice: 'sesion was successfully created.' }
         format.json { render :show, status: :created, location: @sesion }
       else
         format.html { render :new }


### PR DESCRIPTION
Al guardar una cita/sesión se renderizaba la vista de mis_sesiones lo que era una molestia al paciente.