### PR TITLE
Fix[migration]: Update schema version to last migration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190318135917) do
+ActiveRecord::Schema.define(version: 20190329054533) do
 
   create_table "dieta", force: :cascade do |t|
     t.string "dietaPDF"


### PR DESCRIPTION
Version of schema was not commited in PR #110.

* Update schema version with `rake db:migrate`

<img width="1901" alt="Screen Shot 2019-04-25 at 3 46 17 PM" src="https://user-images.githubusercontent.com/6835119/56767967-a3969c00-6772-11e9-99ab-fc96ea7cba8e.png">
